### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
   * Move source package lintian overrides to debian/source.
   * Bump debhelper from old 11 to 12.
   * Add missing build dependency on dh addon.
+  * Update renamed lintian tag names in lintian overrides.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 17 Nov 2019 02:30:01 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
   * Bump debhelper from old 11 to 12.
   * Add missing build dependency on dh addon.
   * Update renamed lintian tag names in lintian overrides.
+  * Remove Section on tex-gyre that duplicates source.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 17 Nov 2019 02:30:01 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Move source package lintian overrides to debian/source.
   * Bump debhelper from old 11 to 12.
+  * Add missing build dependency on dh addon.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 17 Nov 2019 02:30:01 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: tex
 Priority: optional
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), tex-common
 Build-Depends-Indep: tex-common (>= 6)
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/tex-gyre.git

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Vcs-Browser: https://github.com/debian-tex/tex-gyre
 Homepage: http://www.gust.org.pl/projects/e-foundry/tex-gyre/
 
 Package: tex-gyre
-Section: tex
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,1 +1,1 @@
-tex-gyre source: no-debian-copyright
+tex-gyre source: no-debian-copyright-in-source


### PR DESCRIPTION
Fix some issues reported by lintian
* Add missing build dependency on dh addon. ([missing-build-dependency-for-dh_command](https://lintian.debian.org/tags/missing-build-dependency-for-dh_command.html))
* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag.html))
* Remove Section on tex-gyre that duplicates source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/tex-gyre/48cf22b2-e77d-43d7-95a8-98e0f33fc1e8.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/48cf22b2-e77d-43d7-95a8-98e0f33fc1e8/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/48cf22b2-e77d-43d7-95a8-98e0f33fc1e8/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/48cf22b2-e77d-43d7-95a8-98e0f33fc1e8/diffoscope)).
