### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -16,6 +16,13 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
   * Lintian Override:
     I: tex-gyre source: debian-watch-file-is-missing
 
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on tex-common.
+    + fonts-texgyre: Drop versioned constraint on tex-gyre in Replaces.
+    + fonts-texgyre: Drop versioned constraint on tex-gyre in Breaks.
+    + Remove 2 maintscript entries from 1 files.
+
  -- Hilmar Preusse <hille42@web.de>  Sun, 17 Jan 2021 23:40:26 +0100
 
 tex-gyre (20180621-3) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	Hilmar Preusse <hille42@web.de>
 Build-Depends: debhelper-compat (= 12),
-	tex-common (>= 6)
+	tex-common
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/tex-gyre.git
 Vcs-Browser: https://github.com/debian-tex/tex-gyre
@@ -32,8 +32,7 @@ Section: fonts
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}
-Replaces: tex-gyre (<= 2.004.1-4)
-Breaks: tex-gyre (<= 2.004.1-4), fontconfig-config (<< 2.11.0)
+Breaks: fontconfig-config (<< 2.11.0)
 Multi-Arch: foreign
 Description: OpenType fonts based on URW Fonts
  The TeX Gyre project, following the Latin Modern project, aims at providing

--- a/debian/maintscript
+++ b/debian/maintscript
@@ -1,2 +1,0 @@
-rm_conffile /etc/defoma/hints/ttf-gyre.hints 2.004.1-2
-rm_conffile /etc/texmf/updmap.d/20tex-gyre.cfg 2.004.1-2.1


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/tex-gyre/8f123b63-b49f-4484-93a4-89d17f421717.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package fonts-texgyre: lines which differ (wdiff format)
* Breaks: fontconfig-config (<< [-2.11.0), tex-gyre (<= 2.004.1-4)-] {+2.11.0)+}
* [-Replaces: tex-gyre (<= 2.004.1-4)-]

No differences were encountered between the control files of package \*\*tex-gyre\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8f123b63-b49f-4484-93a4-89d17f421717/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8f123b63-b49f-4484-93a4-89d17f421717/diffoscope)).
