### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -22,6 +22,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
     + Remove 2 maintscript entries from 1 files.
   * Use secure URI in Homepage field.
   * Remove 1 obsolete maintscript entry.
+  * Bump debhelper from old 12 to 13.
 
  -- Hilmar Preusse <hille42@web.de>  Sun, 17 Jan 2021 23:40:26 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -20,6 +20,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
     + fonts-texgyre: Drop versioned constraint on tex-gyre in Replaces.
     + fonts-texgyre: Drop versioned constraint on tex-gyre in Breaks.
     + Remove 2 maintscript entries from 1 files.
+  * Use secure URI in Homepage field.
 
  -- Hilmar Preusse <hille42@web.de>  Sun, 17 Jan 2021 23:40:26 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -21,6 +21,7 @@ tex-gyre (20180621-4) UNRELEASED; urgency=medium
     + fonts-texgyre: Drop versioned constraint on tex-gyre in Breaks.
     + Remove 2 maintscript entries from 1 files.
   * Use secure URI in Homepage field.
+  * Remove 1 obsolete maintscript entry.
 
  -- Hilmar Preusse <hille42@web.de>  Sun, 17 Jan 2021 23:40:26 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian TeX Task Force <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	Hilmar Preusse <hille42@web.de>
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
 	tex-common
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/tex-gyre.git

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 12),
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/tex-gyre.git
 Vcs-Browser: https://github.com/debian-tex/tex-gyre
-Homepage: http://www.gust.org.pl/projects/e-foundry/tex-gyre/
+Homepage: https://www.gust.org.pl/projects/e-foundry/tex-gyre/
 
 Package: tex-gyre
 Architecture: all

--- a/debian/fonts-texgyre.maintscript
+++ b/debian/fonts-texgyre.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/fonts/conf.avail/30-fonts-texgyre-aliases.conf 2.004.2-4.1~ fonts-texgyre


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Remove 1 obsolete maintscript entry.

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/tex-gyre/7d04443d-f3c5-4d40-970d-003c1d112e3e.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/prerm
### Control files of package fonts-texgyre: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.gust.org.pl/projects/e-foundry/tex-gyre/-] {+https&#8203;://www.gust.org.pl/projects/e-foundry/tex-gyre/+}
### Control files of package tex-gyre: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.gust.org.pl/projects/e-foundry/tex-gyre/-] {+https&#8203;://www.gust.org.pl/projects/e-foundry/tex-gyre/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7d04443d-f3c5-4d40-970d-003c1d112e3e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7d04443d-f3c5-4d40-970d-003c1d112e3e/diffoscope)).
