### PR TITLE
debian/copyright: use spaces rather than tabs to start continuation lines

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tex-gyre (20180621-5) UNRELEASED; urgency=medium
+
+  * debian/copyright: use spaces rather than tabs to start continuation lines.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 29 Sep 2022 19:30:46 -0000
+
 tex-gyre (20180621-4) unstable; urgency=medium
 
   [ Hilmar Preusse ]

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,149 +4,149 @@ Source: http://www.gust.org.pl/projects/e-foundry/tex-gyre/
 
 Comment: Common Files
 Files:	fonts/enc/dvips/tex-gyre/*.enc
-	doc/fonts/tex-gyre*/MANIFEST*
-	doc/fonts/tex-gyre*/*LICENSE*
-	doc/fonts/tex-gyre*/README*
-	doc/fonts/tex-gyre-math/INSTALL.txt
-	doc/fonts/tex-gyre-math/math-test*
-	doc/fonts/tex-gyre/goadb999.nam
-	tlpkg/tlpobj/*
+ 	doc/fonts/tex-gyre*/MANIFEST*
+ 	doc/fonts/tex-gyre*/*LICENSE*
+ 	doc/fonts/tex-gyre*/README*
+ 	doc/fonts/tex-gyre-math/INSTALL.txt
+ 	doc/fonts/tex-gyre-math/math-test*
+ 	doc/fonts/tex-gyre/goadb999.nam
+ 	tlpkg/tlpobj/*
 Copyright: Copyright (C) 2006-2018 Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Adventor
 Files:	doc/fonts/tex-gyre/qag*
-	fonts/map/dvips/tex-gyre/qag*
-	fonts/tfm/public/tex-gyre/*qag*
-	fonts/afm/public/tex-gyre/qag*
-	fonts/type1/public/tex-gyre/qag*
-	fonts/opentype/public/tex-gyre/texgyreadventor*
-	source/fonts/tex-gyre/*adventor*
-	tex/latex/tex-gyre/*qag*
-	tex/latex/tex-gyre/tgadventor.sty
+ 	fonts/map/dvips/tex-gyre/qag*
+ 	fonts/tfm/public/tex-gyre/*qag*
+ 	fonts/afm/public/tex-gyre/qag*
+ 	fonts/type1/public/tex-gyre/qag*
+ 	fonts/opentype/public/tex-gyre/texgyreadventor*
+ 	source/fonts/tex-gyre/*adventor*
+ 	tex/latex/tex-gyre/*qag*
+ 	tex/latex/tex-gyre/tgadventor.sty
 Copyright: Copyright (C) 2007-2018 Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Bonum
 Files:	doc/fonts/tex-gyre/qbk*
-	fonts/map/dvips/tex-gyre/qbk*
-	fonts/tfm/public/tex-gyre/*qbk*
-	fonts/afm/public/tex-gyre/qbk*
-	fonts/type1/public/tex-gyre/qbk*
-	fonts/opentype/public/tex-gyre/texgyrebonum*
-	tex/latex/tex-gyre/*qbk*
-	tex/latex/tex-gyre/qbookman.sty
-	tex/latex/tex-gyre/tgbonum.sty
+ 	fonts/map/dvips/tex-gyre/qbk*
+ 	fonts/tfm/public/tex-gyre/*qbk*
+ 	fonts/afm/public/tex-gyre/qbk*
+ 	fonts/type1/public/tex-gyre/qbk*
+ 	fonts/opentype/public/tex-gyre/texgyrebonum*
+ 	tex/latex/tex-gyre/*qbk*
+ 	tex/latex/tex-gyre/qbookman.sty
+ 	tex/latex/tex-gyre/tgbonum.sty
 Copyright: Copyright (C) 2007-2009 Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Chorus
 Files:	doc/fonts/tex-gyre/qzc*
-	fonts/map/dvips/tex-gyre/qzc*
-	fonts/tfm/public/tex-gyre/*qzc*
-	fonts/afm/public/tex-gyre/qzc*
-	fonts/type1/public/tex-gyre/qzc*
-	fonts/opentype/public/tex-gyre/texgyrechorus*
-	tex/latex/tex-gyre/*qzc*
-	tex/latex/tex-gyre/qzapfcha.sty
-	tex/latex/tex-gyre/tgchorus.sty
+ 	fonts/map/dvips/tex-gyre/qzc*
+ 	fonts/tfm/public/tex-gyre/*qzc*
+ 	fonts/afm/public/tex-gyre/qzc*
+ 	fonts/type1/public/tex-gyre/qzc*
+ 	fonts/opentype/public/tex-gyre/texgyrechorus*
+ 	tex/latex/tex-gyre/*qzc*
+ 	tex/latex/tex-gyre/qzapfcha.sty
+ 	tex/latex/tex-gyre/tgchorus.sty
 Copyright: Copyright (C) 2007-2009 Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Cursor
 Files:	doc/fonts/tex-gyre/qcr*
-	fonts/map/dvips/tex-gyre/qcr*.map
-	fonts/tfm/public/tex-gyre/*qcr*
-	fonts/afm/public/tex-gyre/qcr*.afm
-	fonts/type1/public/tex-gyre/qcr*.pfb
-	fonts/type1/public/tex-gyre/qcr*.pfm
-	fonts/opentype/public/tex-gyre/texgyrecursor*
-	tex/latex/tex-gyre/*qcr*
-	tex/latex/tex-gyre/qcourier.sty
-	tex/latex/tex-gyre/tgcursor.sty
+ 	fonts/map/dvips/tex-gyre/qcr*.map
+ 	fonts/tfm/public/tex-gyre/*qcr*
+ 	fonts/afm/public/tex-gyre/qcr*.afm
+ 	fonts/type1/public/tex-gyre/qcr*.pfb
+ 	fonts/type1/public/tex-gyre/qcr*.pfm
+ 	fonts/opentype/public/tex-gyre/texgyrecursor*
+ 	tex/latex/tex-gyre/*qcr*
+ 	tex/latex/tex-gyre/qcourier.sty
+ 	tex/latex/tex-gyre/tgcursor.sty
 Copyright: Copyright (C) 2007-2009 Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Heros
 Files:	doc/fonts/tex-gyre/qhv*
-	fonts/map/dvips/tex-gyre/qhv*
-	fonts/tfm/public/tex-gyre/*qhv*
-	fonts/afm/public/tex-gyre/qhv*
-	fonts/type1/public/tex-gyre/qhv*
-	fonts/opentype/public/tex-gyre/texgyreheros*
-	tex/latex/tex-gyre/*qhv*
-	tex/latex/tex-gyre/qswiss.sty
-	tex/latex/tex-gyre/tgheros.sty
+ 	fonts/map/dvips/tex-gyre/qhv*
+ 	fonts/tfm/public/tex-gyre/*qhv*
+ 	fonts/afm/public/tex-gyre/qhv*
+ 	fonts/type1/public/tex-gyre/qhv*
+ 	fonts/opentype/public/tex-gyre/texgyreheros*
+ 	tex/latex/tex-gyre/*qhv*
+ 	tex/latex/tex-gyre/qswiss.sty
+ 	tex/latex/tex-gyre/tgheros.sty
 Copyright: Copyright (C) 2007-2018  Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Pagella
 Files:	doc/fonts/tex-gyre/qpl*
-	fonts/map/dvips/tex-gyre/qpl*
-	fonts/tfm/public/tex-gyre/*qpl*
-	fonts/afm/public/tex-gyre/qpl*
-	fonts/type1/public/tex-gyre/qpl*
-	fonts/opentype/public/tex-gyre/texgyrepagella*
-	source/fonts/tex-gyre/*pagella*
-	tex/latex/tex-gyre/*qpl*
-	tex/latex/tex-gyre/qpalatin.sty
-	tex/latex/tex-gyre/tgpagella.sty
+ 	fonts/map/dvips/tex-gyre/qpl*
+ 	fonts/tfm/public/tex-gyre/*qpl*
+ 	fonts/afm/public/tex-gyre/qpl*
+ 	fonts/type1/public/tex-gyre/qpl*
+ 	fonts/opentype/public/tex-gyre/texgyrepagella*
+ 	source/fonts/tex-gyre/*pagella*
+ 	tex/latex/tex-gyre/*qpl*
+ 	tex/latex/tex-gyre/qpalatin.sty
+ 	tex/latex/tex-gyre/tgpagella.sty
 Copyright: Copyright (C) 2007-2018  Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Schola
 Files:	doc/fonts/tex-gyre/qcs*
-	fonts/map/dvips/tex-gyre/qcs*
-	fonts/tfm/public/tex-gyre/*qcs*
-	fonts/afm/public/tex-gyre/qcs*
-	fonts/type1/public/tex-gyre/qcs*
-	fonts/opentype/public/tex-gyre/texgyreschola*
-	tex/latex/tex-gyre/*qcs*
-	tex/latex/tex-gyre/tgschola.sty
+ 	fonts/map/dvips/tex-gyre/qcs*
+ 	fonts/tfm/public/tex-gyre/*qcs*
+ 	fonts/afm/public/tex-gyre/qcs*
+ 	fonts/type1/public/tex-gyre/qcs*
+ 	fonts/opentype/public/tex-gyre/texgyreschola*
+ 	tex/latex/tex-gyre/*qcs*
+ 	tex/latex/tex-gyre/tgschola.sty
 Copyright: Copyright (C) 2007-2009  Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Termes
 Files:	doc/fonts/tex-gyre/qtm*
-	fonts/map/dvips/tex-gyre/qtm*
-	fonts/tfm/public/tex-gyre/*qtm*
-	fonts/afm/public/tex-gyre/qtm*
-	fonts/type1/public/tex-gyre/qtm*
-	fonts/opentype/public/tex-gyre/texgyretermes*
-	tex/latex/tex-gyre/*qtm*
-	tex/latex/tex-gyre/qtimes.sty
-	tex/latex/tex-gyre/tgtermes.sty
+ 	fonts/map/dvips/tex-gyre/qtm*
+ 	fonts/tfm/public/tex-gyre/*qtm*
+ 	fonts/afm/public/tex-gyre/qtm*
+ 	fonts/type1/public/tex-gyre/qtm*
+ 	fonts/opentype/public/tex-gyre/texgyretermes*
+ 	tex/latex/tex-gyre/*qtm*
+ 	tex/latex/tex-gyre/qtimes.sty
+ 	tex/latex/tex-gyre/tgtermes.sty
 Copyright: Copyright (C) 2006-2009  Bogus\l{}aw Jackowski and Janusz M. Nowacki
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Bonum-Math
 Files: doc/fonts/tex-gyre-math/test-*-texgyre_bonum_math.*
-	fonts/opentype/public/tex-gyre-math/texgyrebonum-math.otf
+ 	fonts/opentype/public/tex-gyre-math/texgyrebonum-math.otf
 Copyright: Copyright (C) 2013-2014  B. Jackowski, P. Strzelczyk and P. Pianowski
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Pagella-Math
 Files: doc/fonts/tex-gyre-math/test-*-texgyre_pagella_math.*
-	fonts/opentype/public/tex-gyre-math/texgyrepagella-math.otf
+ 	fonts/opentype/public/tex-gyre-math/texgyrepagella-math.otf
 Copyright: Copyright (C) 2012-2014  B. Jackowski, P. Strzelczyk and P. Pianowski
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Schola-Math
 Files: doc/fonts/tex-gyre-math/test-*-texgyre_schola_math.*
-	fonts/opentype/public/tex-gyre-math/texgyreschola-math.otf
+ 	fonts/opentype/public/tex-gyre-math/texgyreschola-math.otf
 Copyright: Copyright (C) 2014  B. Jackowski, P. Strzelczyk and P. Pianowski
 License: GUST-Font-License
 
 Comment: TeX-Gyre-Termes-Math
 Files: doc/fonts/tex-gyre-math/test-*-texgyre_termes_math.*
-	fonts/opentype/public/tex-gyre-math/texgyretermes-math.otf
+ 	fonts/opentype/public/tex-gyre-math/texgyretermes-math.otf
 Copyright: Copyright (C) 2012-2014  B. Jackowski, P. Strzelczyk and P. Pianowski
 License: GUST-Font-License
 
 Comment: TeX-Gyre-DejaVu-Math
 Files: doc/fonts/tex-gyre-math/test-*-texgyre_dejavu_math.*
-	fonts/opentype/public/tex-gyre-math/texgyredejavu-math.otf
-	source/fonts/tex-gyre-math/texgyredejavu-math.sfd
+ 	fonts/opentype/public/tex-gyre-math/texgyredejavu-math.otf
+ 	source/fonts/tex-gyre-math/texgyredejavu-math.sfd
 Copyright: Copyright (C) 2016  B. Jackowski, P. Strzelczyk and P. Pianowski
 License: GUST-Font-License and DejaVu-License
 


### PR DESCRIPTION

debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/tex-gyre/2236e687-0b81-4a69-a57f-81796b31374f.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/2236e687-0b81-4a69-a57f-81796b31374f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/2236e687-0b81-4a69-a57f-81796b31374f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/2236e687-0b81-4a69-a57f-81796b31374f/diffoscope)).
